### PR TITLE
Add Web Server log processing to the module

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,13 @@ The very basic steps needed for a user to get the module up and running. This ca
 
 ## Usage
 
-This section is where you describe how to customize, configure, and do the fancy stuff with your module here. It's especially helpful if you include usage examples and code samples for doing things with your module.
+```yaml
+io_filebeat::web_logs: true
+io_filebeat::fields:
+  region: "%{hiera('region')}"
+  server_type: "%{hiera('server_type')}"
+  
+```
 
 ## Reference
 

--- a/README.md
+++ b/README.md
@@ -44,11 +44,17 @@ The very basic steps needed for a user to get the module up and running. This ca
 ## Usage
 
 ```yaml
-io_filebeat::web_logs: true
+io_filebeat::major_version: '5'
+io_filebeat::config_dir: 'C:/Program Files/filebeat/conf.d'
+io_filebeat::weblogic: true
+io_filebeat::pia_access: true
 io_filebeat::fields:
   region: "%{hiera('region')}"
   server_type: "%{hiera('server_type')}"
-  
+io_filebeat::output:
+  logstash:
+    hosts:
+      - elk.psadmin.io:5044
 ```
 
 ## Reference

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,0 +1,38 @@
+class io_filebeat (
+  $ensure                    = hiera('ensure', 'present'),
+  $psft_install_user_name    = hiera('psft_install_user_name', undef),
+  $oracle_install_group_name = hiera('oracle_install_group_name', undef),
+  $domain_user               = hiera('domain_user', undef),
+  $pia_domain_list           = hiera_hash('pia_domain_list'),
+  $appserver_domain_list     = hiera_hash('appserver_domain_list'),
+  $prcs_domain_list          = hiera_hash('prcs_domain_list'),
+  $web_logs                  = undef,
+  $access_logs               = undef,
+  $app_logs                  = undef,
+  $prcs_logs                 = undef,
+  $fields                    = undef,
+) {
+
+  if $pia_domain_list { validate_hash($pia_domain_list) }
+  if $appserver_domain_list { validate_hash($appserver_domain_list) }
+  if $prcs_domain_list { validate_hash($prcs_domain_list) }
+
+  case $::osfamily {
+    'windows': {
+      $fileowner       = $domain_user
+    }
+    'AIX': {
+      $fileowner       = $psft_install_user_name
+    }
+    'Solaris': {
+      $fileowner       = $psft_install_user_name
+    }
+    default: {
+      $fileowner       = $psft_install_user_name
+    }
+  }
+
+if ($io_filebeat::web_logs != undef) {
+  contain ::io_filebeat::web_logs
+}
+

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,13 +3,13 @@ class io_filebeat (
   $psft_install_user_name    = hiera('psft_install_user_name', undef),
   $oracle_install_group_name = hiera('oracle_install_group_name', undef),
   $domain_user               = hiera('domain_user', undef),
-  $pia_domain_list           = hiera_hash('pia_domain_list'),
-  $appserver_domain_list     = hiera_hash('appserver_domain_list'),
-  $prcs_domain_list          = hiera_hash('prcs_domain_list'),
-  $web_logs                  = undef,
-  $access_logs               = undef,
-  $app_logs                  = undef,
-  $prcs_logs                 = undef,
+  $pia_domain_list           = hiera_hash('pia_domain_list', undef),
+  $appserver_domain_list     = hiera_hash('appserver_domain_list', undef),
+  $prcs_domain_list          = hiera_hash('prcs_domain_list', undef),
+  $weblogic                  = false,
+  $access_logs               = false,
+  $app_logs                  = false,
+  $prcs_logs                 = false,
   $fields                    = undef,
 ) {
 
@@ -32,7 +32,8 @@ class io_filebeat (
     }
   }
 
-if ($io_filebeat::web_logs != undef) {
-  contain ::io_filebeat::web_logs
-}
+  if ($weblogic) {
+    contain ::io_filebeat::weblogic
+  }
 
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,16 +6,22 @@ class io_filebeat (
   $pia_domain_list           = hiera_hash('pia_domain_list', undef),
   $appserver_domain_list     = hiera_hash('appserver_domain_list', undef),
   $prcs_domain_list          = hiera_hash('prcs_domain_list', undef),
+  $config_dir                = '/opt/filebeat/conf.d',
+  $major_version              = '5.4.0',
   $weblogic                  = false,
+  $pia_access                = false,
   $access_logs               = false,
   $app_logs                  = false,
   $prcs_logs                 = false,
   $fields                    = undef,
+  $output                    = undef,
 ) {
 
-  if $pia_domain_list { validate_hash($pia_domain_list) }
-  if $appserver_domain_list { validate_hash($appserver_domain_list) }
-  if $prcs_domain_list { validate_hash($prcs_domain_list) }
+  # contain ::filebeat
+
+  # if $pia_domain_list { validate_hash($pia_domain_list) }
+  # if $appserver_domain_list { validate_hash($appserver_domain_list) }
+  # if $prcs_domain_list { validate_hash($prcs_domain_list) }
 
   case $::osfamily {
     'windows': {
@@ -32,8 +38,17 @@ class io_filebeat (
     }
   }
 
+  class { 'filebeat': 
+    config_dir     => $config_dir,
+    major_version  => $major_version,
+    outputs        => $output,
+  }
+
   if ($weblogic) {
     contain ::io_filebeat::weblogic
+  }
+  if ($pia_access) {
+    contain ::io_filebeat::pia_access
   }
 
 }

--- a/manifests/pia_access.pp
+++ b/manifests/pia_access.pp
@@ -1,25 +1,19 @@
-class io_filebeat::weblogic (
+class io_filebeat::pia_access (
   $ensure          = $io_filebeat::ensure,
   $pia_domain_list = $io_filebeat::pia_domain_list,
   $fields          = $io_filebeat::fields,
 ) inherits io_filebeat {
 
   $pia_domain_list.each |$domain_name, $pia_domain_info| {
-    filebeat::prospector {"${domain_name}-weblogic":
+    filebeat::prospector {"${domain_name}-pia-access":
       paths             => [
-        "${pia_domain_info['ps_cfg_home_dir']}/webserv/${domain_name}/servers/PIA/logs/PIA_weblogic.log",
+        "${pia_domain_info['ps_cfg_home_dir']}/webserv/${domain_name}/servers/PIA/logs/PIA_access.log",
       ],
-      doc_type          => 'weblogic_log',
+      doc_type          => 'access_log',
       input_type        => 'log',
       ignore_older      => '24h',
       fields_under_root => true,
       tail_files        => true,
-      multiline         => {
-        pattern => "^####",
-        negate => true,
-        what => "previous",
-        match => "after",
-      },
       fields            => $fields,
     }
   }

--- a/manifests/web_logs.pp
+++ b/manifests/web_logs.pp
@@ -1,0 +1,27 @@
+class io_filebeat::web_logs (
+  $ensure          = $io_filebeat::ensure,
+  $pia_domain_list = $io_filebeat::pia_domain_list,
+  $fields          = $io_filebeat::fields,
+) inherits io_filebeat {
+
+  $pia_domain_list.each |$domain_name, $pia_domain_info| {
+    filebeat::prospector {"${domain_name}-weblogic":
+      paths             => [
+        "${pia_domain_info['ps_cfg_home_dir']}/webserv/${domain_name}/servers/PIA/logs/PIA_weblogic.log",
+      ],
+      doc_type          => 'weblogic_server_log',
+      input_type        => 'log',
+      ignore_older      => '24h',
+      fields_under_root => true,
+      tail_files        => true,
+      multiline         => {
+        pattern => "^####",
+        negate => true,
+        what => "previous",
+        match => "after",
+      },
+      fields            => $fields,
+    }
+  }
+
+}

--- a/manifests/weblogic.pp
+++ b/manifests/weblogic.pp
@@ -1,7 +1,7 @@
-class io_filebeat::web_logs (
+class io_filebeat::weblogic (
   $ensure          = $io_filebeat::ensure,
   $pia_domain_list = $io_filebeat::pia_domain_list,
-  $fields          = $io_filebeat::fields,
+  # $fields          = $io_filebeat::fields,
 ) inherits io_filebeat {
 
   $pia_domain_list.each |$domain_name, $pia_domain_info| {
@@ -9,7 +9,7 @@ class io_filebeat::web_logs (
       paths             => [
         "${pia_domain_info['ps_cfg_home_dir']}/webserv/${domain_name}/servers/PIA/logs/PIA_weblogic.log",
       ],
-      doc_type          => 'weblogic_server_log',
+      doc_type          => 'weblogic_log',
       input_type        => 'log',
       ignore_older      => '24h',
       fields_under_root => true,
@@ -20,7 +20,7 @@ class io_filebeat::web_logs (
         what => "previous",
         match => "after",
       },
-      fields            => $fields,
+      # fields            => $fields,
     }
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -9,7 +9,8 @@
     {
       "name": "puppetlabs-stdlib",
       "version_requirement": ">= 4.13.1 < 5.0.0"
-    }
+    },
+      { "name": "pcfens-filebeat", "version_requirement": ">= 2.0.0 < 5.0.0" }
   ],
   "operatingsystem_support": [
     {


### PR DESCRIPTION
The `io_filebeat` module will now deploy prospectors for the `PIA_Access` and `PIA_Weblogic` log files for each domain in `pia_domain_list:`.

The module uses Hiera Hashing by default.